### PR TITLE
added default provider in env to manage between IMGIX and SIRV

### DIFF
--- a/src/functions/getCDNConfigs.js
+++ b/src/functions/getCDNConfigs.js
@@ -1,8 +1,20 @@
-module.exports = async function ({ cdnOptimizationAttribute = "thumbnail" }) {
+module.exports = async function ({
+  cdnOptimizationAttribute = "thumbnail",
+  optimizationProvider = "IMGIX",
+}) {
   try {
     const validCDNConfigAttributes = ["thumbnail", "reduced_quality"];
     let validCDNConfigAttributesConfigs = {};
-    let defaultCDNImageOptimizationConfigs = process.env.CDN_OPTIMIZATIONS;
+    let defaultCDNImageOptimizationConfigs;
+
+    if (optimizationProvider === "IMGIX") {
+      defaultCDNImageOptimizationConfigs = process.env.CDN_OPTIMIZATIONS;
+    }
+
+    if (optimizationProvider === "SIRV") {
+      defaultCDNImageOptimizationConfigs = process.env.CDN_OPTIMIZATIONS_SIRV;
+    }
+    
     let defaultCdnImageConfig = null;
     if (
       defaultCDNImageOptimizationConfigs &&

--- a/src/serializers/file/single.js
+++ b/src/serializers/file/single.js
@@ -31,9 +31,19 @@ const setImgixUrl = (file) => {
   return file;
 };
 
+const setSirvUrl = (file) => {
+  const sirvUrl = process.env.SIRV_URL;
+  const pathURL = file["path_to_file"];
+  if (sirvUrl && typeof sirvUrl === "string") {
+    file["sirv_url"] = sirvUrl.concat(
+      pathURL.slice(pathURL.lastIndexOf("/") + 1, pathURL.length)
+    );
+  }
+  return file;
+};
+
 module.exports = async (instance, includes = []) => {
   instance = setDownloadurl(instance);
-  instance = setImgixUrl(instance);
 
   const attributes = [
     "uuid",
@@ -46,8 +56,18 @@ module.exports = async (instance, includes = []) => {
     "created_at",
     "updated_at",
     "download_url",
-    "imgix_url",
   ];
+
+  if (process.env.DEFAULT_IMAGE_OPTIMIZATION_PROVIDER === "IMGIX") {
+    instance = setImgixUrl(instance);
+    attributes.push("imgix_url");
+  }
+
+  if (process.env.DEFAULT_IMAGE_OPTIMIZATION_PROVIDER === "SIRV") {
+    instance = setSirvUrl(instance);
+    attributes.push("sirv_url");
+  }
+
   const tokenObject = pickKeysFromObject(instance, attributes);
   return tokenObject;
 };

--- a/src/stories/Files/CanView/story.js
+++ b/src/stories/Files/CanView/story.js
@@ -53,12 +53,16 @@ const respond = async ({ prepareResult, handleResult }) => {
 
       let downloadUrl = fileObject.download_url;
       let optimizedURLs = {};
-      if (fileObject.imgix_url) {
+      if (
+        fileObject.imgix_url &&
+        process.env.DEFAULT_IMAGE_OPTIMIZATION_PROVIDER === "IMGIX"
+      ) {
         downloadUrl = `${fileObject.imgix_url}`;
         if (isImageTypeMatched) {
           let cdnOptimization = prepareResult.cdn_optimization;
           const cdnConfigs = await getCDNConfigs({
             cdnOptimizationAttribute: cdnOptimization,
+            optimizationProvider: "IMGIX",
           });
           if (cdnConfigs && cdnConfigs.defaultCdnImageConfig) {
             downloadUrl = `${fileObject.imgix_url}?${cdnConfigs.defaultCdnImageConfig}`;
@@ -69,6 +73,33 @@ const respond = async ({ prepareResult, handleResult }) => {
                 optimizedURLs[
                   `${attribute}`
                 ] = `${fileObject.imgix_url}?${cdnConfigs.validCDNConfigAttributesConfigs[attribute]}`;
+              }
+            });
+          }
+        }
+      }
+
+      if (
+        fileObject.sirv_url &&
+        process.env.DEFAULT_IMAGE_OPTIMIZATION_PROVIDER === "SIRV"
+      ) {
+        downloadUrl = `${fileObject.sirv_url}`;
+        if (isImageTypeMatched) {
+          let cdnOptimization = prepareResult.cdn_optimization;
+          const cdnConfigs = await getCDNConfigs({
+            cdnOptimizationAttribute: cdnOptimization,
+            optimizationProvider: "SIRV",
+          });
+          if (cdnConfigs && cdnConfigs.defaultCdnImageConfig) {
+            downloadUrl = `${fileObject.sirv_url}?${cdnConfigs.defaultCdnImageConfig}`;
+          }
+
+          if (cdnConfigs && cdnConfigs.validCDNConfigAttributes) {
+            cdnConfigs.validCDNConfigAttributes.forEach((attribute) => {
+              if (cdnConfigs.validCDNConfigAttributesConfigs) {
+                optimizedURLs[
+                  `${attribute}`
+                ] = `${fileObject.sirv_url}?${cdnConfigs.validCDNConfigAttributesConfigs[attribute]}`;
               }
             });
           }


### PR DESCRIPTION
Added default provider in env to switch between IMGIX and SIRV, now if we have provider as IMGIX then only IMGIX optimisations and urls will be in the response.